### PR TITLE
feat: 로그인 페이지에 reducer 적용, 토큰 유무 판별로 "/"리다이렉트 기능 구현 완료

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,25 @@
 import { Routes, Route, Navigate, BrowserRouter } from "react-router-dom";
 import styled from "styled-components";
 import { createTheme, ThemeProvider } from "@mui/material";
+import { useEffect } from "react";
 import { Cookies } from "react-cookie";
-import { useState, useEffect } from "react";
+import { useDispatch, useSelector} from "react-redux";
 
 //페이지 컴포넌트
-// import LoginPage from "./pages/Auth/LoginPage";
+import LoginPage from "./pages/Auth/LoginPage";
 import Main from "./pages/Main/Main";
 import BottomNav from "./components/Layout/BottomNav";
-import LoginPage from "./pages/Auth/LoginPage";
-// import Main from "./pages/Main/Main";
 // import Recommend from "./pages/Recommend/RecommendPage";
-// import BottomNav from "./components/Layout/BottomNav";
 // import AddPost from "./pages/AddPost/AddPostPage";
 // import MyLike from "./pages/LikePost/LikePage";
 // import MyPage from "./pages/MyPage/MyPage";
 // import Post from "./pages/Post/PostPage";
 // import Search from "./pages/Search/SearchPage";
-// import SignUp from "./pages/Auth/SignUpPage";
+import SignUp from "./pages/Auth/SignUpPage";
+
+//Redux
+import { RootState } from "./redux/store";
+import { setIsAuthenticated } from "./redux/modules/auth";
 
 const theme = createTheme({
   typography: {
@@ -27,6 +29,7 @@ const theme = createTheme({
 
 const cookies = new Cookies();
 
+
 //RouteConfig type정의
 interface RouteConfig {
   element: JSX.Element;
@@ -35,20 +38,27 @@ interface RouteConfig {
 }
 
 function App(): JSX.Element {
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false); // 로그인 상태
+  const dispatch = useDispatch();
+  const isAuthenticated = useSelector((state: RootState) => state.auth.isAuthenticated);
 
   useEffect(() => {
-    const token = cookies.get("access_token");
-    setIsAuthenticated(!!token);
-  }, []);
-
+    const token = document.cookie.includes("access_token");
+    dispatch(setIsAuthenticated(!!token));
+  }, [dispatch]);
+  
+  const PrivateRoute = ({ element }: { element: JSX.Element }): JSX.Element => {
+    const token = cookies.get("access_token"); // 토큰 존재 여부 확인
+    console.log("토큰있음");
+    return token ? element : <Navigate to="/" replace />; // 토큰 없으면 로그인 페이지로 리다이렉트
+  };
+  
   const shouldShowBottomNav = (): boolean => {
     const noBottomNavRoutes = ["/", "/signup", "/signup1", "/post/addpost"];
     return !noBottomNavRoutes.includes(location.pathname);
   };
 
   const routes: RouteConfig[] = [
-    { path: "/", element: <LoginPage setIsAuthenticated={setIsAuthenticated} /> },
+    { path: "/", element: <LoginPage /> },
     // { path: "/recommend", element: <Recommend />, private: true },
     // { path: "/addpost", element: <AddPost />, private: true },
     // { path: "/like", element: <MyLike />, private: true },
@@ -56,19 +66,14 @@ function App(): JSX.Element {
     { path: "/main", element: <Main />, private: true },
     // { path: "/post/:id", element: <Post />, private: true },
     // { path: "/search", element: <Search />, private: true },
-    // { path: "/signup", element: <SignUp /> },
+    { path: "/signup", element: <SignUp /> },
   ];
-
-  const PrivateRoute = ({ element }: { element: JSX.Element }): JSX.Element =>
-    isAuthenticated ? element : <Navigate to="/" replace />;
 
   return (
     <ThemeProvider theme={theme}>
       <BrowserRouter>
         <Container>
-          {
-            shouldShowBottomNav() ? <BottomNav /> : null
-          }
+          {shouldShowBottomNav() ? <BottomNav /> : null}
           <Routes>
             {
               routes.map((route) =>

--- a/src/pages/Auth/LoginPage.tsx
+++ b/src/pages/Auth/LoginPage.tsx
@@ -1,13 +1,9 @@
-import React, { FC } from "react";
+import React from "react";
 import styled from "styled-components";
 import { Link, useNavigate } from "react-router-dom";
 import LoginForm from "./components/LoginForm";
 
-interface LoginPageProps {
-    setIsAuthenticated: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-const LoginPage: FC<LoginPageProps> = ({ setIsAuthenticated }) => {
+const LoginPage: React.FC = () => {
     const navigate = useNavigate();
 
     return (
@@ -15,7 +11,7 @@ const LoginPage: FC<LoginPageProps> = ({ setIsAuthenticated }) => {
             <Header>
                 <Title>Soon-Market</Title>
             </Header>
-            <LoginForm setIsAuthenticated={setIsAuthenticated} />
+            <LoginForm />
             <Footer>
                 <StyledLink to="/findid">아이디 찾기</StyledLink>ㅣ
                 <StyledLink to="/findpassword">비밀번호 찾기</StyledLink>ㅣ

--- a/src/pages/Auth/SignUpPage.tsx
+++ b/src/pages/Auth/SignUpPage.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import styled from "styled-components";
+import { Link, useNavigate } from "react-router-dom";
+import SignUpForm from "./components/SignUpForm";
+
+const SignUpPage: React.FC = () => {
+    const navigate = useNavigate();
+
+    return (
+        <SignUpContainer>
+            <Header>
+                <Title>Soon-Market</Title>
+            </Header>
+            <SignUpForm/>
+            <Footer>
+                <StyledLink to="/findid">아이디 찾기</StyledLink>ㅣ
+                <StyledLink to="/findpassword">비밀번호 찾기</StyledLink>ㅣ
+                <StyledLink to="/signup">가입하기</StyledLink>
+            </Footer>
+        </SignUpContainer>
+    );
+};
+
+// Styled Components
+const SignUpContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    font-family: 'SUIT', sans-serif;
+`;
+
+const Header = styled.div`
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+`;
+
+const Title = styled.h1`
+    margin: 100px; /* 원하는 margin 값으로 설정 */
+    font-family: 'SUIT', sans-serif; /* 폰트 설정 */
+`;
+
+const Footer = styled.div`
+    font-size: 15px;
+    color: gray;
+    text-align: center;
+    margin-top: 20px;
+`;
+
+const StyledLink = styled(Link)`
+    text-decoration: none;
+    color: black;
+    margin: 0 5px;
+`;
+
+export default SignUpPage;

--- a/src/pages/Auth/components/LoginForm.tsx
+++ b/src/pages/Auth/components/LoginForm.tsx
@@ -1,36 +1,22 @@
-import React, { useState, FC, FormEvent } from "react";
+import React, { useState, FormEvent } from "react";
 import styled from "styled-components";
 import HighlightOffOutlinedIcon from "@mui/icons-material/HighlightOffOutlined";
 import { Button, IconButton, TextField } from "@mui/material";
 import useLogin from "../../../api/Auth/useLogin";
+import { useDispatch } from "react-redux";
+import { setIsAuthenticated } from "../../../redux/modules/auth";
 
-interface LoginFormProps{
-    setIsAuthenticated: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-const LoginForm: FC<LoginFormProps> = ({ setIsAuthenticated }) => {
+const LoginForm: React.FC = () => {
   const [id, setId] = useState("");
   const [password, setPassword] = useState("");
   const [emailError, setEmailError] = useState("");
-
   const login = useLogin();
+  const dispatch = useDispatch();
 
-  const validateEmail = (value: string) => {
-    const schDomainRegex = /^[a-zA-Z0-9._%+-]+@sch\.ac\.kr$/;
-    return schDomainRegex.test(value);
-  }
+  const validateEmail = (value: string) => /^[a-zA-Z0-9._%+-]+@sch\.ac\.kr$/.test(value);
 
   const handleEmailBlur = () => {
-    if (!id) {
-      // 필드가 비어있으면 에러 초기화
-      setEmailError("");
-      return;
-    }
-    if (!validateEmail(id)) {
-      setEmailError("이메일은 @sch.ac.kr 도메인만 허용됩니다.");
-    } else {
-      setEmailError("");
-    }
+    setEmailError(!id ? "" : !validateEmail(id) ? "이메일은 @sch.ac.kr 도메인만 허용됩니다." : "");
   };
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -39,12 +25,11 @@ const LoginForm: FC<LoginFormProps> = ({ setIsAuthenticated }) => {
       setEmailError("이메일은 @sch.ac.kr 도메인만 허용됩니다.");
       return;
     }
-
     try {
         await login(id, password);
-        setIsAuthenticated(true);
+        dispatch(setIsAuthenticated(true));
       } catch {
-        setIsAuthenticated(false);
+        dispatch(setIsAuthenticated(false));
       }
   };
 


### PR DESCRIPTION
문제: 로그인 하지 않아도 /main 접속 가능, 로그인 이후 "/"로 간 뒤 "/main"으로 재접속시 안되는 현상 발생

해결: redux 사용하여 setIsAuthentication 전역 사용, privateRoute 구현, useEffect로 setIsAuthenticated dispatch로 확인하여 토큰 유무 판별 이후 private:true 인 라우터 접속할 시 "/"로 리다이렉트 구현